### PR TITLE
two changes to make it work on macos

### DIFF
--- a/rephraser.py
+++ b/rephraser.py
@@ -17,6 +17,10 @@ mpqueue = None # Will contain Queue
 MAXQUEUESIZE = 100000 # Number of work items that is reasonable to have on the queue
 worker_num = 0 # Will be changed before creating workers
 
+if sys.platform == "darwin":
+  MAXQUEUESIZE=32767 #max allowed mp queue size on mac
+  mp.set_start_method("fork") #necessary for workers to inherit global vars on mac
+
 def sigint_handler(signal_received, frame):
   # Following wrapup might not complete for minutes with 3 workers
   # for i in range(worker_num):


### PR DESCRIPTION
* maxqueue on mac has to be 32767: https://github.com/uqfoundation/multiprocess/issues/66


* if you don't specify using fork method, it will use spawn on mac, which means global vars (in particular _dct_) don't get inherited https://docs.python.org/dev/library/multiprocessing.html#contexts-and-start-methods
(despite what it implies there, specifying fork _does_ work on mac)
